### PR TITLE
Adding cli.js to generate a self contained html viewer

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -26,14 +26,14 @@ var genHtml = function(title, rules) {
 
 program
     .version(version)
-    .usage('[options] <grammer_file>')
+    .usage('[options] <grammar_file>')
     .option('-o, --output <output>', 'output file', null)
     .parse(process.argv);
 
 var input = program.args[0] || null;
 
 if (!input) {
-    console.error('ERROR: Missing a required input grammer file.');
+    console.error('ERROR: Missing a required input grammar file.');
     console.log(program.help());
     process.exit(1)
 }

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+var path = require('path');
+var fs = require('fs');
+
+var program = require('commander');
+var handlebars = require('handlebars');
+
+var parse = require('pegjs/lib/parser').parse;
+var grammkit = require('./grammkit');
+
+var version = require('./package.json').version;
+
+var getHtml = function (svg,title) {
+	var raw_template = fs.readFileSync(path.join(__dirname, 'template', 'viewer.html'));
+	var data = {
+		title: title,
+		style: fs.readFileSync(path.join(__dirname, 'template','style.css'),  'utf-8'),
+    svg: svg
+	};
+	var template = handlebars.compile(raw_template.toString());
+	return template(data);
+}
+
+program
+	.version(version)
+  .usage('[options] <grammer_file>')
+	.option('-o, --output <output>', 'output file', null)
+	.option('-g, --grammer <format>', '"pegjs" or "ebnf". Defaults to pegjs', 'pegjs')
+  .option('--html', 'generate html file for viewing in a browser')
+  .parse(process.argv);
+
+var input = program.args[0] || null;
+
+if (!input) {
+	console.error('ERROR: Missing a required input grammer file.');
+	console.log(program.help());
+	process.exit(1)
+}
+
+var p = path.parse(input);
+var title = p.base;
+
+if (program.output === null) {
+	p.dir = '.';
+	p.ext = program.html ? '.html':'.svg';
+	delete p.base;
+	program.output = path.format(p);
+}
+
+var grammar = parse(fs.readFileSync(input, 'utf-8'));
+var svg = grammkit.diagram(grammar.rules[0]);
+
+if (program.html) {
+	fs.writeFileSync(program.output, getHtml(svg, title), 'utf-8');	
+} else {
+	fs.writeFileSync(program.output, svg, 'utf-8');
+}

--- a/cli.js
+++ b/cli.js
@@ -8,26 +8,26 @@ var handlebars = require('handlebars');
 
 var parse = require('pegjs/lib/parser').parse;
 var grammkit = require('./grammkit');
+var getReferences = require('./lib/peg-references');
 
 var version = require('./package.json').version;
 
-var getHtml = function (svg,title) {
+var genHtml = function (title, rules) {
 	var raw_template = fs.readFileSync(path.join(__dirname, 'template', 'viewer.html'));
 	var data = {
 		title: title,
 		style: fs.readFileSync(path.join(__dirname, 'template','style.css'),  'utf-8'),
-    svg: svg
+		rules: rules
 	};
 	var template = handlebars.compile(raw_template.toString());
 	return template(data);
 }
 
+
 program
 	.version(version)
   .usage('[options] <grammer_file>')
 	.option('-o, --output <output>', 'output file', null)
-	.option('-g, --grammer <format>', '"pegjs" or "ebnf". Defaults to pegjs', 'pegjs')
-  .option('--html', 'generate html file for viewing in a browser')
   .parse(process.argv);
 
 var input = program.args[0] || null;
@@ -43,16 +43,23 @@ var title = p.base;
 
 if (program.output === null) {
 	p.dir = '.';
-	p.ext = program.html ? '.html':'.svg';
+	p.ext = '.html';
 	delete p.base;
 	program.output = path.format(p);
 }
 
 var grammar = parse(fs.readFileSync(input, 'utf-8'));
-var svg = grammkit.diagram(grammar.rules[0]);
+var references = getReferences(grammar);
+var rules = grammar.rules.map(function(rule) {
+	return {
+		name: rule.name,
+		diagram: grammkit.diagram(rule),
+		usedBy: references[rule.name].usedBy,
+		references: references[rule.name].references
+	};
+});
 
-if (program.html) {
-	fs.writeFileSync(program.output, getHtml(svg, title), 'utf-8');	
-} else {
-	fs.writeFileSync(program.output, svg, 'utf-8');
-}
+var html = genHtml(title, rules)
+
+fs.writeFileSync(program.output, html, 'utf-8');
+console.log('generated ' + program.output);

--- a/cli.js
+++ b/cli.js
@@ -12,51 +12,54 @@ var getReferences = require('./lib/peg-references');
 
 var version = require('./package.json').version;
 
-var genHtml = function (title, rules) {
-	var raw_template = fs.readFileSync(path.join(__dirname, 'template', 'viewer.html'));
-	var data = {
-		title: title,
-		style: fs.readFileSync(path.join(__dirname, 'template','style.css'),  'utf-8'),
-		rules: rules
-	};
-	var template = handlebars.compile(raw_template.toString());
-	return template(data);
+var genHtml = function(title, rules) {
+    var raw_template = fs.readFileSync(path.join(__dirname, 'template', 'viewer.html'));
+    var data = {
+        title: title,
+        style: fs.readFileSync(path.join(__dirname, 'template', 'style.css'), 'utf-8'),
+        rules: rules
+    };
+    var template = handlebars.compile(raw_template.toString());
+    return template(data);
 }
 
 
 program
-	.version(version)
-  .usage('[options] <grammer_file>')
-	.option('-o, --output <output>', 'output file', null)
-  .parse(process.argv);
+    .version(version)
+    .usage('[options] <grammer_file>')
+    .option('-o, --output <output>', 'output file', null)
+    .parse(process.argv);
 
 var input = program.args[0] || null;
 
 if (!input) {
-	console.error('ERROR: Missing a required input grammer file.');
-	console.log(program.help());
-	process.exit(1)
+    console.error('ERROR: Missing a required input grammer file.');
+    console.log(program.help());
+    process.exit(1)
 }
 
 var p = path.parse(input);
 var title = p.base;
 
 if (program.output === null) {
-	p.dir = '.';
-	p.ext = '.html';
-	delete p.base;
-	program.output = path.format(p);
+    p.dir = '.';
+    p.ext = '.html';
+    delete p.base;
+    program.output = path.format(p);
 }
 
 var grammar = parse(fs.readFileSync(input, 'utf-8'));
-var references = getReferences(grammar);
+var References = getReferences(grammar);
 var rules = grammar.rules.map(function(rule) {
-	return {
-		name: rule.name,
-		diagram: grammkit.diagram(rule),
-		usedBy: references[rule.name].usedBy,
-		references: references[rule.name].references
-	};
+    const _ref = References[rule.name] || null;
+    const usedBy = (_ref && _ref.usedBy) || null;
+    const references = (_ref && _ref.references) || null;
+    return {
+        name: rule.name,
+        diagram: grammkit.diagram(rule),
+        usedBy: usedBy,
+        references: references
+    };
 });
 
 var html = genHtml(title, rules)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "debounce": "^1.0.0",
     "handlebars": "^4.0.5",
     "jsesc": "^0.5.0",
-    "pegjs": "^0.9.0",
+    "pegjs": "^0.8.0",
     "railroad-diagrams": "^1.0.0",
     "react": "^0.12.2",
     "whitescape": "^0.5.0"

--- a/package.json
+++ b/package.json
@@ -1,18 +1,21 @@
 {
   "name": "grammkit",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A tool to generate diagrams for parser grammars",
   "main": "grammkit.js",
   "scripts": {
     "test": "jest"
   },
+  "bin": "./cli.js",
   "dependencies": {
     "bootstrap": "^3.3.2",
     "browser-request": "^0.3.3",
     "classnames": "^1.1.4",
+    "commander": "^2.9.0",
     "debounce": "^1.0.0",
+    "handlebars": "^4.0.5",
     "jsesc": "^0.5.0",
-    "pegjs": "^0.8.0",
+    "pegjs": "^0.9.0",
     "railroad-diagrams": "^1.0.0",
     "react": "^0.12.2",
     "whitescape": "^0.5.0"

--- a/template/style.css
+++ b/template/style.css
@@ -1,0 +1,52 @@
+svg.railroad-diagram {
+  background-color: hsl(30,20%,95%);
+}
+svg.railroad-diagram path {
+  stroke-width: 3;
+  stroke: black;
+  fill: rgba(0,0,0,0);
+}
+svg.railroad-diagram text {
+  font: bold 14px monospace;
+  text-anchor: middle;
+  cursor: pointer;
+}
+svg.railroad-diagram text.label {
+  text-anchor: start;
+}
+svg.railroad-diagram text.comment {
+  font: italic 12px monospace;
+}
+svg.railroad-diagram rect {
+  stroke-width: 3;
+  stroke: black;
+  fill: hsl(120,100%,90%);
+}
+
+body {
+  background-color: hsl(30,20%,95%);
+}
+
+input[type=text].form-control, textarea.form-control {
+  background-color:  hsl(30,20%,98%);;
+}
+
+.load-examples {
+  margin-left: 20px;
+  margin-top: 10px;
+  margin-bottom: 25px;
+}
+
+.load-examples a {
+  margin-left: 10px;
+}
+
+textarea.form-control.grammar-edit {
+  height: 400px;
+  margin-bottom: 20px;
+  font-family: monospace;
+}
+
+.alert {
+  word-wrap: break-word;
+}

--- a/template/viewer.html
+++ b/template/viewer.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+	<head>
+    <meta charset="utf-8">
+    <title>Railroad diagram for {{title}}</title>
+		<style>
+			{{style}}
+		</style>
+		<style>
+			.container {
+				margin: auto;
+				padding: 2em;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="container">
+			{{{svg}}}
+		</div>
+	</body>
+</html>

--- a/template/viewer.html
+++ b/template/viewer.html
@@ -7,15 +7,48 @@
 			{{style}}
 		</style>
 		<style>
+			body {
+				font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+			}
+			.rule {
+				padding-top: 4em;
+			}
 			.container {
 				margin: auto;
 				padding: 2em;
 			}
 		</style>
+		<script>
+			function svgBlockClick(ev) {
+				if(ev.target.tagName === 'text') {
+					location.hash = ev.target.textContent;
+				}
+			}
+			</script>
 	</head>
 	<body>
 		<div class="container">
-			{{{svg}}}
+			<h1>{{title}}</h1>
+			{{#rules}}
+			  <div class="rule">
+					<h2 id={{name}}>{{name}}</h2>
+					<div onclick=svgBlockClick>
+						{{{diagram}}}
+					</div>
+					<div>
+						Used by:
+						{{#usedBy}}
+						<a href="#{{this}}">{{this}}</a>
+						{{/usedBy}}
+					</div>
+					<div>
+						References:
+						{{#references}}
+						<a href="#{{this}}">{{this}}</a>
+						{{/references}}
+					</div>
+				</div>
+			{{/rules}}
 		</div>
 	</body>
 </html>


### PR DESCRIPTION
The ability of GrammKit to visualize pegjs grammer is very useful.
I wanted a cli for this, so created a simple wrapper. 
Hopefully you'll agree with the implementation and accept the PR.
