### PR TITLE
change ohm-js dep away from gh ref

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "handlebars": "^4.0.5",
     "jsesc": "^0.5.0",
     "lodash": "^4.17.2",
-    "ohm-js": "harc/ohm#b7db5de9c68e62dd053ebc535c3dbec348e039bb",
+    "ohm-js": "^0.14.0",
     "pegjs": "^0.8.0",
     "railroad-diagrams": "^1.0.0",
     "react": "^0.12.2",


### PR DESCRIPTION
0.14.0 was released, and having a direct gh dep causes this weird-ass error in travis:

```
npm ERR! code ENOPACKAGEJSON
npm ERR! package.json Non-registry package missing package.json: ohm-js@github:harc/ohm#b7db5de9c68e62dd053ebc535c3dbec348e039bb.
npm ERR! package.json npm can't find a package.json file in your current directory.
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/travis/.npm/_logs/2018-01-28T06_58_40_289Z-debug.log
The command "eval npm install  " failed. Retrying, 2 of 3.
```