### PR TITLE
bump bootstrap to 4.* to resolve security warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grammkit",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "A tool to generate diagrams for parser grammars",
   "main": "grammkit.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "bin": "./cli.js",
   "dependencies": {
-    "bootstrap": "^3.3.2",
     "browser-request": "^0.3.3",
     "classnames": "^1.1.4",
     "commander": "^2.9.0",
@@ -25,6 +24,7 @@
     "whitescape": "^0.5.0"
   },
   "devDependencies": {
+    "bootstrap": "^4.1.3",
     "gulp": "^3.8.11",
     "gulp-webpack": "^1.3.0",
     "jest": "^21.0.2",


### PR DESCRIPTION
there's a security warning out for bootstrap 3.3.7, and you use 3.3.2, which resolves to 3.3.7 on npm

there is no fix in 3.* (or, indeed, even into 4.1.*,) so I bumped you to modern

gulp still builds.  jest still passes.  the example image still looks sane.  i don't really know how to test this