### PR TITLE
Fix onclick events for SVG elements

### DIFF
--- a/template/viewer.html
+++ b/template/viewer.html
@@ -34,7 +34,7 @@
 			{{#rules}}
 			  <div class="rule">
 					<h3 id={{name}}>{{name}}</h3>
-					<div onclick=svgBlockClick>
+					<div onclick="svgBlockClick(event)">
 						{{{diagram}}}
 					</div>
 					<div>


### PR DESCRIPTION
Clicking on a node in any of the SVG elements should navigate to the corresponding node definition, but the event was not being passed to the svgBlockClick handler.

Tested on Chrome v71.0.3578.80 and Firefox 60.2.0esr, on Linux (Ubuntu).