### PR TITLE
Upgrade to handlebars 4.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "bin": "./cli.js",
   "dependencies": {
     "commander": "4.0.1",
-    "handlebars": "4.5.3",
+    "handlebars": "4.7.6",
     "jsesc": "2.5.2",
     "lodash": "4.17.15",
     "ohm-js": "0.14.0",


### PR DESCRIPTION
This is the result of running `npm audit fix` to remove the transitive
dependency on a version of `minimist` that has a low severity
vulnerability.

```
$ npm audit

                       === npm audit security report ===

# Run  npm install handlebars@4.7.6  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ minimist                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ handlebars                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ handlebars > optimist > minimist                             │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1179                            │
└───────────────┴──────────────────────────────────────────────────────────────┘

found 1 low severity vulnerability in 151201 scanned packages
  run `npm audit fix` to fix 1 of them.
```